### PR TITLE
Ameliorate the unidiomatic Turkish expression "aksiyon almak"

### DIFF
--- a/site/tr.njk
+++ b/site/tr.njk
@@ -20,7 +20,7 @@ lang: tr
                 Hükümetlerimiz
                 <a href="https://en.wikipedia.org/wiki/Severe_acute_respiratory_syndrome_coronavirus_2">SARS-CoV-2</a>
                 salgınını ve <a href="https://en.wikipedia.org/wiki/Coronavirus_disease_2019">COVID-19 pandemisini</a> önlemede başarısız kaldı.
-                Yavaş reaksiyonları, insanları yatıştırma politikaları ve ekonomiyi istikrarlı tutma çabaları, milyonları etkileyecek bu hastalığa karşı önlem almalarını engelliyor. Bu dünyanın bir vatandaşı olarak aksiyon almamızın ve COVID-19’a karşı savaşmamızın vakti geldi.
+                Yavaş reaksiyonları, insanları yatıştırma politikaları ve ekonomiyi istikrarlı tutma çabaları, milyonları etkileyecek bu hastalığa karşı önlem almalarını engelliyor. Bu dünyanın bir vatandaşı olarak harekete geçmemizin ve COVID-19’a karşı savaşmamızın vakti geldi.
                 <br /><br />
                 Açık dille söylemek gerekirse: <strong>Lanet Olası Evinde Kal!</strong>
             </p>


### PR DESCRIPTION
It seems that the idiom "take action" got translated literally into Turkish, resulting in the unidiomatic expression of "aksiyon almak". I replaced this with the corresponding correct idiom "harekete geçmek".