### PR TITLE
Feature/SFW meta tags

### DIFF
--- a/site/globals/site.json
+++ b/site/globals/site.json
@@ -2,6 +2,7 @@
     "name": "#StayTheFuckHome",
     "nameSfw": "#StayTheF—Home",
     "url": "https://staythefuckhome.com",
+    "urlSfw": "https://staythebeephome.com",
     "images": {
         "logo": "/images/logo/logo.svg",
         "favicon": "/images/favicon.ico",

--- a/site/includes/components/social-meta.njk
+++ b/site/includes/components/social-meta.njk
@@ -12,7 +12,7 @@
 <meta name="og:title" content="{% if meta_title %}{{ meta_title }}{% else %}{{ title }}{% endif %} | {% if sfw %}{{ site.nameSfw }}{% else %}{{ site.name }}{% endif %}">
 <meta name="og:description" content="{% if meta_description %}{{ meta_description }}{% else %}{{ excerpt }}{% endif %}">
 <meta name="og:image" content="{{ site.url }}{% if sfw %}{{ site.images.ogSfw }}{% else %}{{ site.images.og }}{% endif %}">
-<meta name="og:url" content="{{ site.url }}{{ page.url }}">
+<meta name="og:url" content="{% if sfw %}{{ site.urlSfw }}{{ page.url }}{% else %}{{ site.url }}{{ page.url }}{% endif %}">
 <meta name="og:site_name" content="{% if sfw %}{{ site.nameSfw }}{% else %}{{ site.name }}{% endif %}">
 <meta name="og:locale" content="en_US">
 <meta name="og:type" content="website">

--- a/site/includes/layouts/default.njk
+++ b/site/includes/layouts/default.njk
@@ -34,7 +34,7 @@
     <link rel="icon" type="image/png" href="{{ site.images.favicon }}">
 
     {# canonical #}
-    <link rel="canonical" href="{{ site.url }}{{ page.url }}">
+    <link rel="canonical" href="{% if sfw %}{{ site.urlSfw }}{{ page.url }}{% else %}{{ site.url }}{{ page.url }}{% endif %}">
 
     {% if page.url | isLocalized(langs) %}
         {% for lang in langs %}


### PR DESCRIPTION
Check if the site is a SFW version. If it is, set URL-oriented metatags to a SFW URL (https://staythebeephome.com). That URL will automatically redirect to /sfw/.

I'm not sure how it'll handle links to other languages – the lang nav links are paths, but will the host force a hard redirect back to /sfw/?

I don't want to be invasive here, so if people landing on staythebeephome.com can't access other languages without changing all the urls or messing with DNS, then we can roll this back and people can just deal with an URL with "fuck" in it. 😄 